### PR TITLE
아티스트 구독 화면에서 아티스트 구독 가능하도록 수정 + 에러 핸들링

### DIFF
--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistDataSource.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistDataSource.kt
@@ -30,7 +30,7 @@ interface ArtistDataSource {
 
     suspend fun subscribeArtists(
         artistIds: List<String>,
-    ): List<SubscriptionArtistId>
+    ): Result<List<SubscriptionArtistId>>
 
     suspend fun unSubscribeArtists(
         artistIds: List<String>,

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistDataSource.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistDataSource.kt
@@ -3,6 +3,7 @@ package com.alreadyoccupiedseat.data.artist
 import com.alreadyoccupiedseat.model.Artist
 import com.alreadyoccupiedseat.model.SearchedArtist
 import com.alreadyoccupiedseat.model.artist.SubscriptionArtistId
+import com.alreadyoccupiedseat.model.artist.UnSubscribedArtist
 
 interface ArtistDataSource {
 
@@ -19,7 +20,7 @@ interface ArtistDataSource {
         genreIds: List<String>? = null,
         cursorId: Int?,
         size: Int,
-    ): List<Artist>
+    ): List<UnSubscribedArtist>
 
     suspend fun getSubscribedArtists(
         sort: String? = null,

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistDataSourceImpl.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistDataSourceImpl.kt
@@ -6,6 +6,7 @@ import com.alreadyoccupiedseat.model.SearchedArtist
 import com.alreadyoccupiedseat.model.artist.SubscribeArtistsRequest
 import com.alreadyoccupiedseat.model.artist.SubscriptionArtistId
 import com.alreadyoccupiedseat.model.artist.UnSubscribeArtistsRequest
+import com.alreadyoccupiedseat.model.artist.UnSubscribedArtist
 import com.alreadyoccupiedseat.network.ArtistService
 import javax.inject.Inject
 
@@ -37,7 +38,7 @@ class ArtistDataSourceImpl @Inject constructor(
         genreIds: List<String>?,
         cursorId: Int?,
         size: Int,
-    ): List<Artist> {
+    ): List<UnSubscribedArtist> {
         return artistService.getUnsubscribedArtists(
             sortedStandard,
             artistGenderApiTypes,

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistDataSourceImpl.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistDataSourceImpl.kt
@@ -61,9 +61,12 @@ class ArtistDataSourceImpl @Inject constructor(
         ).body()?.data?.data ?: emptyList()
     }
 
-    override suspend fun subscribeArtists(artistIds: List<String>): List<SubscriptionArtistId> {
-        return artistService.subscribeArtists(SubscribeArtistsRequest(artistIds))
-            .body()?.data?.subscriptionArtistIds ?: emptyList()
+    override suspend fun subscribeArtists(artistIds: List<String>): Result<List<SubscriptionArtistId>> {
+        return runCatching {
+            artistService.subscribeArtists(SubscribeArtistsRequest(artistIds)).getResult {
+                it.data.subscriptionArtistIds
+            }
+        }
     }
 
     override suspend fun unSubscribeArtists(artistIds: List<String>): List<String> {

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistRepository.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistRepository.kt
@@ -30,7 +30,7 @@ interface ArtistRepository {
 
     suspend fun subscribeArtists(
         artistIds: List<String>,
-    ): List<SubscriptionArtistId>
+    ): Result<List<SubscriptionArtistId>>
 
     suspend fun unSubscribeArtists(
         artistIds: List<String>,

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistRepository.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistRepository.kt
@@ -3,6 +3,7 @@ package com.alreadyoccupiedseat.data.artist
 import com.alreadyoccupiedseat.model.Artist
 import com.alreadyoccupiedseat.model.SearchedArtist
 import com.alreadyoccupiedseat.model.artist.SubscriptionArtistId
+import com.alreadyoccupiedseat.model.artist.UnSubscribedArtist
 
 interface ArtistRepository {
 
@@ -19,7 +20,7 @@ interface ArtistRepository {
         genreIds: List<String>? = null,
         cursorId: Int? = null,
         size: Int,
-    ): List<Artist>
+    ): List<UnSubscribedArtist>
 
     suspend fun getSubscribedArtists(
         sort: String? = null,

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistRepositoryImpl.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.alreadyoccupiedseat.data.artist
 import com.alreadyoccupiedseat.model.Artist
 import com.alreadyoccupiedseat.model.SearchedArtist
 import com.alreadyoccupiedseat.model.artist.SubscriptionArtistId
+import com.alreadyoccupiedseat.model.artist.UnSubscribedArtist
 import javax.inject.Inject
 
 class ArtistRepositoryImpl @Inject constructor(
@@ -28,7 +29,7 @@ class ArtistRepositoryImpl @Inject constructor(
         genreIds: List<String>?,
         cursorId: Int?,
         size: Int,
-    ): List<Artist> {
+    ): List<UnSubscribedArtist> {
         return artistDataSource.getUnsubscribedArtists(
             sortedStandard,
             artistGenderApiTypes,

--- a/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistRepositoryImpl.kt
+++ b/core/data/src/main/java/com/alreadyoccupiedseat/data/artist/ArtistRepositoryImpl.kt
@@ -52,7 +52,7 @@ class ArtistRepositoryImpl @Inject constructor(
         )
     }
 
-    override suspend fun subscribeArtists(artistIds: List<String>): List<SubscriptionArtistId> {
+    override suspend fun subscribeArtists(artistIds: List<String>): Result<List<SubscriptionArtistId>> {
         return artistDataSource.subscribeArtists(artistIds)
     }
 

--- a/core/network/src/main/java/com/alreadyoccupiedseat/network/ArtistService.kt
+++ b/core/network/src/main/java/com/alreadyoccupiedseat/network/ArtistService.kt
@@ -8,6 +8,7 @@ import com.alreadyoccupiedseat.model.artist.SubscribeArtistsRequest
 import com.alreadyoccupiedseat.model.artist.SubscribeArtistsResponse
 import com.alreadyoccupiedseat.model.artist.UnSubscribeArtistsRequest
 import com.alreadyoccupiedseat.model.artist.UnSubscribeArtistsResponse
+import com.alreadyoccupiedseat.model.artist.UnSubscribedArtist
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -31,7 +32,7 @@ interface ArtistService {
         @Query("genreIds") genreIds: List<String>? = null,
         @Query("cursorId") cursorId: Int?,
         @Query("size") size: Int,
-    ): Response<ApiResult<PagingData<Artist>>>
+    ): Response<ApiResult<PagingData<UnSubscribedArtist>>>
 
     // TODO: Make sort to enum class
     @GET("api/v1/artists/subscriptions")

--- a/feature/home/src/main/java/com/alreadyoccupiedseat/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/alreadyoccupiedseat/home/HomeViewModel.kt
@@ -9,6 +9,7 @@ import com.alreadyoccupiedseat.data.show.ShowRepository
 import com.alreadyoccupiedseat.data.toApiErrorResult
 import com.alreadyoccupiedseat.designsystem.R
 import com.alreadyoccupiedseat.model.Artist
+import com.alreadyoccupiedseat.model.artist.UnSubscribedArtist
 import com.alreadyoccupiedseat.model.show.ShowPreview
 import com.alreadyoccupiedseat.model.show.ShowType
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -24,7 +25,7 @@ data class HomeScreenState(
     val genreList: List<Pair<Int, Int>> = emptyList(),
     val entireShowList: List<ShowPreview> = emptyList(),
     val recommendedShowList: List<ShowPreview> = emptyList(),
-    val unSubscribedArtists: List<Artist> = emptyList(),
+    val unSubscribedArtists: List<UnSubscribedArtist> = emptyList(),
     val nickName: String = String.EMPTY
 )
 

--- a/feature/search/src/main/java/com/alreadyoccupiedseat/search/SearchViewModel.kt
+++ b/feature/search/src/main/java/com/alreadyoccupiedseat/search/SearchViewModel.kt
@@ -148,19 +148,25 @@ class SearchViewModel @Inject constructor(
 
         val result = artistRepository.subscribeArtists(listOf(artistId))
 
-        reduce {
-            state.copy(
-                searchedArtists = state.searchedArtists.map { subscribedArtist ->
-                    if (subscribedArtist.artistSpotifyId == result.first().artistSpotifyId) {
-                        subscribedArtist.copy(isSubscribed = true)
-                    } else {
-                        subscribedArtist
+        result.onSuccess {
+
+            reduce {
+                state.copy(
+                    searchedArtists = state.searchedArtists.map { subscribedArtist ->
+                        if (subscribedArtist.spotifyId == it.first().spotifyId) {
+                            subscribedArtist.copy(isSubscribed = true)
+                        } else {
+                            subscribedArtist
+                        }
                     }
-                }
-            )
+                )
+            }
+
+            postSideEffect(SearchScreenEvent.SubscribeArtistSuccess)
+        }.onFailure {
+            errorLog(it.toApiErrorResult().message)
         }
 
-        postSideEffect(SearchScreenEvent.SubscribeArtistSuccess)
     }
 
     fun unSubscribeArtist() = intent {

--- a/feature/search/src/main/java/com/alreadyoccupiedseat/search/SearchedSection.kt
+++ b/feature/search/src/main/java/com/alreadyoccupiedseat/search/SearchedSection.kt
@@ -158,8 +158,7 @@ fun SearchedSection(
                                 onUnSubscribeTargetArtistChanged(artist)
                                 onArtistUnSubscriptionSheetVisibilityChanged(true)
                             } else {
-                                // TODO: current it's null
-                                onSubscribeArtist(artist.artistSpotifyId)
+                                onSubscribeArtist(artist.spotifyId)
                             }
                         } else {
                             onLoginSheetVisibilityChanged(true)

--- a/feature/subscription-artist/build.gradle.kts
+++ b/feature/subscription-artist/build.gradle.kts
@@ -64,4 +64,7 @@ dependencies {
     implementation(libs.material)
 
     implementation(libs.coil.kt.compose)
+
+    implementation(libs.orbit.viewmodel)
+    implementation(libs.orbit.compose)
 }

--- a/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistScreen.kt
+++ b/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistScreen.kt
@@ -43,7 +43,10 @@ import com.alreadyoccupiedseat.designsystem.component.snackbar.CheckIconSnackbar
 import com.alreadyoccupiedseat.designsystem.typo.korean.ShowPotKoreanText_H1
 import com.alreadyoccupiedseat.designsystem.typo.korean.ShowPotKoreanText_H2
 import com.alreadyoccupiedseat.model.Artist
+import com.alreadyoccupiedseat.model.artist.UnSubscribedArtist
 import kotlinx.coroutines.launch
+import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
 
 @Composable
 fun SubscriptionArtistScreen(
@@ -53,19 +56,18 @@ fun SubscriptionArtistScreen(
 ) {
 
     val viewModel = hiltViewModel<SubscriptionArtistViewModel>()
-    val state = viewModel.state.collectAsState()
+    val state = viewModel.collectAsState()
 
     val snackbarHostState = remember { SnackbarHostState() }
 
-    LaunchedEffect(true) {
-        viewModel.event.collect {
-            when (it) {
-                SubscriptionArtistScreenEvent.Idle -> {
+    viewModel.collectSideEffect {
+        when (it) {
+            SubscriptionArtistScreenEvent.Idle -> {
 
-                }
-                SubscriptionArtistScreenEvent.SubscribeArtistsSuccess -> {
-                    snackbarHostState.showSnackbar("구독 설정이 완료되었습니다")
-                }
+            }
+
+            SubscriptionArtistScreenEvent.SubscribeArtistsSuccess -> {
+                snackbarHostState.showSnackbar("구독 설정이 완료되었습니다")
             }
         }
     }
@@ -107,8 +109,8 @@ fun SubscriptionArtistScreenContent(
     onBackClicked: () -> Unit,
     onSheetStateChanged: (Boolean) -> Unit = {},
     onSubscribeButtonClicked: () -> Unit = {},
-    onArtistClicked: (Artist) -> Unit = {},
-    checkIsSelected: (Artist) -> Boolean,
+    onArtistClicked: (UnSubscribedArtist) -> Unit = {},
+    checkIsSelected: (UnSubscribedArtist) -> Boolean,
     onLoginRequested: () -> Unit = {},
     onGoToSeeClicked: () -> Unit = {},
 ) {

--- a/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistViewModel.kt
+++ b/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistViewModel.kt
@@ -2,7 +2,9 @@ package com.alreadyoccupiedseat.subscription_artist
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.alreadyoccupiedseat.common.utiils.errorLog
 import com.alreadyoccupiedseat.data.artist.ArtistRepository
+import com.alreadyoccupiedseat.data.toApiErrorResult
 import com.alreadyoccupiedseat.datastore.AccountDataStore
 import com.alreadyoccupiedseat.model.Artist
 import com.alreadyoccupiedseat.model.artist.UnSubscribedArtist
@@ -52,20 +54,26 @@ class SubscriptionArtistViewModel @Inject constructor(
     fun subscribeArtists() = intent {
 
         val artistIds = state.selectedArtists.map { it.spotifyId }
-        val subscribedArtistsIds = artistRepository.subscribeArtists(artistIds).map {
-            it.id
-        }
+        val result = artistRepository.subscribeArtists(artistIds)
 
-        reduce {
-            state.copy(
-                selectedArtists = emptyList(),
-                unsubscribedArtists = state.unsubscribedArtists.filter {
-                    it.id !in subscribedArtistsIds
-                },
-            )
-        }
+        result.onSuccess { subscribedArtistsInfo ->
+            val subscribedIds = subscribedArtistsInfo.map {
+                it.id
+            }
 
-        postSideEffect(SubscriptionArtistScreenEvent.SubscribeArtistsSuccess)
+            reduce {
+                state.copy(
+                    selectedArtists = emptyList(),
+                    unsubscribedArtists = state.unsubscribedArtists.filter {
+                        it.id !in subscribedIds
+                    },
+                )
+            }
+
+            postSideEffect(SubscriptionArtistScreenEvent.SubscribeArtistsSuccess)
+        }.onFailure {
+            errorLog(it.toApiErrorResult().message)
+        }
 
     }
 

--- a/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistViewModel.kt
+++ b/feature/subscription-artist/src/main/java/com/alreadyoccupiedseat/subscription_artist/SubscriptionArtistViewModel.kt
@@ -5,10 +5,12 @@ import androidx.lifecycle.viewModelScope
 import com.alreadyoccupiedseat.data.artist.ArtistRepository
 import com.alreadyoccupiedseat.datastore.AccountDataStore
 import com.alreadyoccupiedseat.model.Artist
+import com.alreadyoccupiedseat.model.artist.UnSubscribedArtist
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
+import org.orbitmvi.orbit.Container
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.viewmodel.container
 import javax.inject.Inject
 
 sealed interface SubscriptionArtistScreenEvent {
@@ -18,8 +20,8 @@ sealed interface SubscriptionArtistScreenEvent {
 }
 
 data class SubscriptionArtistScreenState(
-    val selectedArtists: List<Artist> = emptyList(),
-    val unsubscribedArtists: List<Artist> = emptyList(),
+    val selectedArtists: List<UnSubscribedArtist> = emptyList(),
+    val unsubscribedArtists: List<UnSubscribedArtist> = emptyList(),
     val isLoggedIn: Boolean = false,
     val isSheetVisible: Boolean = false,
 )
@@ -29,73 +31,81 @@ data class SubscriptionArtistScreenState(
 class SubscriptionArtistViewModel @Inject constructor(
     private val artistRepository: ArtistRepository,
     private val accountDataStore: AccountDataStore
-) : ViewModel() {
+) : ViewModel(), ContainerHost<SubscriptionArtistScreenState, SubscriptionArtistScreenEvent> {
 
-    private var _state = MutableStateFlow(SubscriptionArtistScreenState())
-    val state = _state
-
-    private val _event = MutableSharedFlow<SubscriptionArtistScreenEvent>()
-    val event = _event
+    override val container: Container<SubscriptionArtistScreenState, SubscriptionArtistScreenEvent> =
+        container(SubscriptionArtistScreenState())
 
     init {
         getUnsubscribedArtists()
-        viewModelScope.launch {
+        intent {
             accountDataStore.getAccessTokenFlow().collect {
-                _state.value = _state.value.copy(
-                    isLoggedIn = it?.isNotEmpty() ?: false,
-                )
+                reduce {
+                    state.copy(
+                        isLoggedIn = it?.isNotEmpty() ?: false,
+                    )
+                }
             }
         }
     }
 
-    fun subscribeArtists() {
-        viewModelScope.launch {
-            val artistIds = state.value.selectedArtists.map { it.id }
-            val subscribedArtistsIds = artistRepository.subscribeArtists(artistIds).map {
-                it.id
-            }
+    fun subscribeArtists() = intent {
 
-            _state.value = _state.value.copy(
+        val artistIds = state.selectedArtists.map { it.spotifyId }
+        val subscribedArtistsIds = artistRepository.subscribeArtists(artistIds).map {
+            it.id
+        }
+
+        reduce {
+            state.copy(
                 selectedArtists = emptyList(),
-                unsubscribedArtists = state.value.unsubscribedArtists.filter {
+                unsubscribedArtists = state.unsubscribedArtists.filter {
                     it.id !in subscribedArtistsIds
                 },
             )
-            event.emit(SubscriptionArtistScreenEvent.SubscribeArtistsSuccess)
         }
+
+        postSideEffect(SubscriptionArtistScreenEvent.SubscribeArtistsSuccess)
+
     }
 
-    fun selectArtist(artist: Artist) {
+    fun selectArtist(artist: UnSubscribedArtist) = intent {
 
-        if (state.value.selectedArtists.contains(artist)) {
-            _state.value = _state.value.copy(
-                selectedArtists = _state.value.selectedArtists - artist,
-            )
+        if (state.selectedArtists.contains(artist)) {
+            reduce {
+                state.copy(
+                    selectedArtists = state.selectedArtists - artist,
+                )
+            }
         } else {
-            _state.value = _state.value.copy(
-                selectedArtists = _state.value.selectedArtists + artist,
-            )
+            reduce {
+                state.copy(
+                    selectedArtists = state.selectedArtists + artist,
+                )
+            }
         }
 
     }
 
-    fun isSelected(artist: Artist): Boolean {
-        return state.value.selectedArtists.contains(artist)
+    fun isSelected(artist: UnSubscribedArtist): Boolean {
+        return container.stateFlow.value.selectedArtists.contains(artist)
     }
 
-    fun setSheetVisible(isVisible: Boolean) {
-        _state.value = _state.value.copy(
-            isSheetVisible = isVisible,
-        )
-    }
-
-    private fun getUnsubscribedArtists() {
-        viewModelScope.launch {
-            val result = artistRepository.getUnsubscribedArtists(
-                size = 30,
+    fun setSheetVisible(isVisible: Boolean) = intent {
+        reduce {
+            state.copy(
+                isSheetVisible = isVisible,
             )
+        }
+    }
 
-            _state.value = _state.value.copy(
+    private fun getUnsubscribedArtists() = intent {
+        val result = artistRepository.getUnsubscribedArtists(
+            size = 30,
+        )
+
+        reduce {
+            state.copy(
                 unsubscribedArtists = result,
             )
         }

--- a/model/src/main/java/com/alreadyoccupiedseat/model/SearchedArtist.kt
+++ b/model/src/main/java/com/alreadyoccupiedseat/model/SearchedArtist.kt
@@ -7,7 +7,7 @@ data class SearchedArtist(
     val id: String?,
     val imageURL: String,
     val name: String,
-    val artistSpotifyId: String,
+    val spotifyId: String,
     val isSubscribed: Boolean,
 )
 

--- a/model/src/main/java/com/alreadyoccupiedseat/model/artist/SubscriptionArtistId.kt
+++ b/model/src/main/java/com/alreadyoccupiedseat/model/artist/SubscriptionArtistId.kt
@@ -4,6 +4,6 @@ import androidx.annotation.Keep
 
 @Keep
 data class SubscriptionArtistId(
-    val artistSpotifyId: String,
+    val spotifyId: String,
     val id: String?
 )

--- a/model/src/main/java/com/alreadyoccupiedseat/model/artist/UnSubscribedArtist.kt
+++ b/model/src/main/java/com/alreadyoccupiedseat/model/artist/UnSubscribedArtist.kt
@@ -1,0 +1,8 @@
+package com.alreadyoccupiedseat.model.artist
+
+data class UnSubscribedArtist(
+    val id: String,
+    val imageURL: String,
+    val name: String,
+    val spotifyId: String
+)


### PR DESCRIPTION
## 🤘 작업 내용
- 아티스트 구독 화면에서 아티스트 구독 가능하도록 수정
- 에러 핸들링 일부 적용

## 📋 변경된 내용
- 기존 artistSpotifyId 필드명이 spotifyId로 변경 됨

## 💻 동작 화면
- 동작 화면 없음

## 📌 비고
- 비고 없음
