### PR TITLE
쇼팟 바텀 시트 배경 화면 수정

### DIFF
--- a/core/designsystem/src/main/java/com/alreadyoccupiedseat/designsystem/component/bottomSheet/ShowPotBottomSheet.kt
+++ b/core/designsystem/src/main/java/com/alreadyoccupiedseat/designsystem/component/bottomSheet/ShowPotBottomSheet.kt
@@ -22,6 +22,7 @@ fun ShowPotBottomSheet(
         sheetState = sheetState,
         shape = RectangleShape,
         containerColor = ShowpotColor.Gray600,
+        scrimColor = ShowpotColor.Gray800.copy(alpha = 0.7f),
         dragHandle = null
     ) {
         content()


### PR DESCRIPTION
## 🤘 작업 내용
- GUI 동일하게 BottomSheet scrimColor 수정 

## 📋 변경된 내용
- GUI 확인 결과, 모두 Gray800 alpha 0.7f 적용 -> 일괄  적용

## 💻 동작 화면
- 동작 화면 없음

## 📌 비고
- 비고 없음
