### PR TITLE
ui 이슈들 일부 수정(홈 화면 공백, 공연 알림 페이지 폰트, 예매 중인 공연의 알림 설정 버튼 비활성화)

### DIFF
--- a/core/designsystem/src/main/java/com/alreadyoccupiedseat/designsystem/component/button/IconButtonWithShowPotMainButton.kt
+++ b/core/designsystem/src/main/java/com/alreadyoccupiedseat/designsystem/component/button/IconButtonWithShowPotMainButton.kt
@@ -21,7 +21,9 @@ import com.alreadyoccupiedseat.designsystem.component.ShowPotMainButton
 @Composable
 fun IconButtonWithShowPotMainButton(
     icon: Painter,
-    text: String,
+    enableText: String,
+    disEnableText: String,
+    isEnabled: Boolean = true,
     onIconButtonClicked: () -> Unit,
     onMainButtonClicked: () -> Unit,
 ) {
@@ -51,7 +53,8 @@ fun IconButtonWithShowPotMainButton(
         Spacer(modifier = Modifier.width(15.dp))
 
         ShowPotMainButton(
-            text = text,
+            text = if (isEnabled) enableText else disEnableText,
+            enabled = isEnabled
         ) {
             onMainButtonClicked()
         }

--- a/feature/home/src/main/java/com/alreadyoccupiedseat/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/alreadyoccupiedseat/home/HomeScreen.kt
@@ -258,6 +258,10 @@ fun HomeScreenContent(
                     )
                 }
 
+                item {
+                    Spacer(modifier = Modifier.height(6.dp))
+                }
+
                 itemsIndexed(state.entireShowList) { index, show ->
                     val textColor = if (show.isOpen) {
                         ShowpotColor.MainBlue

--- a/feature/notification/src/main/java/com/alreadyoccupiedseat/notification/NotificationScreen.kt
+++ b/feature/notification/src/main/java/com/alreadyoccupiedseat/notification/NotificationScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.alreadyoccupiedseat.designsystem.ShowpotColor
 import com.alreadyoccupiedseat.designsystem.component.IconMenuWithCount
-import com.alreadyoccupiedseat.designsystem.typo.english.ShowPotEnglishText_H0
 import com.alreadyoccupiedseat.designsystem.typo.korean.ShowPotKoreanText_H0
 import com.alreadyoccupiedseat.designsystem.typo.korean.ShowPotKoreanText_H1
 
@@ -114,7 +113,7 @@ fun NotificationScreenContent(
             if (state.isLoggedIn && state.upcomingTicketingShows.isNotEmpty()) {
                 val upcomingTicketShow = state.upcomingTicketingShows[pagerState.currentPage]
                 item {
-                    ShowPotEnglishText_H0(
+                    ShowPotKoreanText_H0(
                         text = upcomingTicketShow.title,
                         modifier = Modifier.padding(horizontal = 16.dp),
                         color = ShowpotColor.Gray100,

--- a/feature/show-detail/src/main/java/com/alreadyoccupiedseat/show_detail/ShowDetailScreen.kt
+++ b/feature/show-detail/src/main/java/com/alreadyoccupiedseat/show_detail/ShowDetailScreen.kt
@@ -34,6 +34,8 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import coil.compose.AsyncImage
+import com.alreadyoccupiedseat.common.utils.getCurrentDateTime
+import com.alreadyoccupiedseat.common.utils.isDate1GreaterOrEqual
 import com.alreadyoccupiedseat.core.extension.EMPTY
 import com.alreadyoccupiedseat.core.extension.isScrollingUp
 import com.alreadyoccupiedseat.designsystem.ShowpotColor
@@ -605,6 +607,8 @@ fun ShowDetailScreenContent(
                     if (state.showDetail?.isInterested == true) painterResource(com.alreadyoccupiedseat.designsystem.R.drawable.ic_heart_36_on)
                     else painterResource(com.alreadyoccupiedseat.designsystem.R.drawable.ic_heart_36_off),
                     stringResource(R.string.set_notification),
+                    "예매가 오픈된 공연이에요.",
+                    isEnabled = isDate1GreaterOrEqual(getCurrentDateTime(), state.showDetail?.ticketingTimes?.first()?.ticketingAt ?: "2999-12-08 00:00").not(),
                     onIconButtonClicked = {
                         if (state.isLoggedIn) onIconButtonClicked()
                         else onLoginSheetVisibilityChanged(true)


### PR DESCRIPTION
## 🤘 작업 내용
- 홈 화면 공백
- 공연 알림 페이지 폰트
- 예매 중인 공연의 알림 설정 버튼 비활성화

## 📋 변경된 내용
- 변경된 내용을 작성해주세요.

## 💻 동작 화면
- 동작 화면 없음

## 📌 비고
- 비고 없음
