### PR TITLE
공연 상세 화면에 댓글 작성시 로그인 유무를 체크하도록 수정

### DIFF
--- a/feature/show-detail/src/main/java/com/alreadyoccupiedseat/show_detail/ShowDetailScreen.kt
+++ b/feature/show-detail/src/main/java/com/alreadyoccupiedseat/show_detail/ShowDetailScreen.kt
@@ -80,10 +80,7 @@ fun ShowDetailScreen(
 
     viewModel.collectSideEffect {
         when (it) {
-            is ShowDetailEvent.Idle -> {
-
-            }
-
+            is ShowDetailEvent.Idle -> {}
             is ShowDetailEvent.AlertRegisterSuccess -> {
                 Toast.makeText(
                     context,
@@ -136,7 +133,11 @@ fun ShowDetailScreen(
             viewModel.changeTicketingSelectionBoxState(it)
         },
         onShowCommentsScreen = {
-            onShowCommentsScreen(showId)
+            state.isLoggedIn.takeIf { it }?.let {
+                onShowCommentsScreen(showId)
+            } ?: run {
+                viewModel.changeLoginSheetVisibility(true)
+            }
         }
     )
 }


### PR DESCRIPTION
## 🤘 작업 내용
- 공연 상세에 댓글을 작성 시에 로그인 유, 무를 체크하도록 수정

## 📋 변경된 내용
- 공연 상세에 댓글을 작성 시에 로그인 유, 무를 체크하고 로그인 바텀 시트 노출

## 💻 동작 화면
![Apr-10-2025 15-04-53](https://github.com/user-attachments/assets/8c2bf1b5-2c67-4dba-b5e6-5f239aa95322)


## 📌 비고
- 비고 없음
